### PR TITLE
Swarm rtl device connection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,7 @@ numpy
 opencv-python
 opencv-contrib-python
 djitellopy
+wifi
+netifaces
+docker
+loguru

--- a/rtl_device/connect.py
+++ b/rtl_device/connect.py
@@ -1,8 +1,11 @@
 import json
 import wifi
 import subprocess
+import netifaces
+import docker
 from loguru import logger
-# Необходимо установить wireless-tools, ifupdown
+
+# Необходимо установить wireless-tools, network-manager
 
 
 def readNetworkConfiguration(json_path):
@@ -14,15 +17,18 @@ def connect(iface, ssid, password) -> bool:
     logger.info(f"Connecting device \'{iface}\' to \'{ssid}\'")
     scanner = wifi.Cell.all(iface)
     available_networks = [cell.ssid for cell in scanner]
+
+    output = ""
     if ssid not in available_networks:
         logger.error(f"SSID {ssid} unreacheble")
         return False
     try:
         output = subprocess.check_output(
             ['nmcli', 'device', 'wifi', 'connect', ssid, 'password', password, 'ifname', iface]).decode(encoding='utf-8').replace("\n", "")
-
         if "successfully" in str(output):
-            logger.success(f'Device \'{iface}\' successfully connected to \'{ssid}\'')
+            logger.info(netifaces.ifaddresses(iface))
+            logger.success(
+                f'Device \'{iface}\' successfully connected to \'{ssid}\'')
             return True
         else:
             logger.error(f"Error while connecting to {ssid}")
@@ -35,7 +41,30 @@ def connect(iface, ssid, password) -> bool:
     return False
 
 
+def createDockerNetwork(name, iface, gateway, subnet):
+    options = dict({("parent", iface)})
+    srv_pool = docker.types.IPAMPool(subnet=subnet, gateway=gateway)
+    ipam = docker.types.IPAMConfig(pool_configs=[srv_pool])
+    client = docker.from_env()
+    docker_networks = client.networks.list([name])
+    if docker_networks != []:
+        logger.warning(
+            f"Network with name {name} already exists, removing it...")
+        network = client.networks.get(docker_networks[0].id)
+        network.remove()
+        logger.info(f'Removed network with id {docker_networks[0].id}')
+    logger.info(f'Creating network with name {name}')
+    client.networks.create(name, "macvlan", options, ipam)
+
+
 if __name__ == "__main__":
-    ifaces = readNetworkConfiguration("networks.json")["ifaces"]
+    config = readNetworkConfiguration("networks.json")
+    ifaces = config["ifaces"]
+    docker_networks = config["docker_networks"]
+    
     for iface in ifaces:
         connect(iface, ifaces[iface]['ssid'], ifaces[iface]['password'])
+    for network in docker_networks:
+        createDockerNetwork(network, docker_networks[network]["iface"],
+                            docker_networks[network]["gateway"],
+                            docker_networks[network]["subnet"])

--- a/rtl_device/connect.py
+++ b/rtl_device/connect.py
@@ -7,8 +7,6 @@ import sys
 from loguru import logger
 from typing import NoReturn
 
-# Необходимо установить wireless-tools, network-manager
-
 
 def readNetworkConfiguration(json_path):
     with open(json_path) as json_file:

--- a/rtl_device/connect.py
+++ b/rtl_device/connect.py
@@ -1,0 +1,41 @@
+import json
+import wifi
+import subprocess
+from loguru import logger
+# Необходимо установить wireless-tools, ifupdown
+
+
+def readNetworkConfiguration(json_path):
+    with open(json_path) as json_file:
+        return json.load(json_file)
+
+
+def connect(iface, ssid, password) -> bool:
+    logger.info(f"Connecting device \'{iface}\' to \'{ssid}\'")
+    scanner = wifi.Cell.all(iface)
+    available_networks = [cell.ssid for cell in scanner]
+    if ssid not in available_networks:
+        logger.error(f"SSID {ssid} unreacheble")
+        return False
+    try:
+        output = subprocess.check_output(
+            ['nmcli', 'device', 'wifi', 'connect', ssid, 'password', password, 'ifname', iface]).decode(encoding='utf-8').replace("\n", "")
+
+        if "successfully" in str(output):
+            logger.success(f'Device \'{iface}\' successfully connected to \'{ssid}\'')
+            return True
+        else:
+            logger.error(f"Error while connecting to {ssid}")
+            logger.error(output)
+            return False
+    except Exception as e:
+        logger.critical(e)
+        logger.debug(output)
+
+    return False
+
+
+if __name__ == "__main__":
+    ifaces = readNetworkConfiguration("networks.json")["ifaces"]
+    for iface in ifaces:
+        connect(iface, ifaces[iface]['ssid'], ifaces[iface]['password'])

--- a/rtl_device/connect.py
+++ b/rtl_device/connect.py
@@ -3,7 +3,9 @@ import wifi
 import subprocess
 import netifaces
 import docker
+import sys
 from loguru import logger
+from typing import NoReturn
 
 # Необходимо установить wireless-tools, network-manager
 
@@ -13,7 +15,7 @@ def readNetworkConfiguration(json_path):
         return json.load(json_file)
 
 
-def connect(iface, ssid, password) -> bool:
+def connect(iface: str, ssid: str, password: str) -> bool:
     logger.info(f"Connecting device \'{iface}\' to \'{ssid}\'")
     scanner = wifi.Cell.all(iface)
     available_networks = [cell.ssid for cell in scanner]
@@ -37,11 +39,12 @@ def connect(iface, ssid, password) -> bool:
     except Exception as e:
         logger.critical(e)
         logger.debug(output)
+        sys.exit(-1)
 
     return False
 
 
-def createDockerNetwork(name, iface, gateway, subnet):
+def createDockerNetwork(name: str, iface: str, gateway: str, subnet: str) -> NoReturn:
     options = dict({("parent", iface)})
     srv_pool = docker.types.IPAMPool(subnet=subnet, gateway=gateway)
     ipam = docker.types.IPAMConfig(pool_configs=[srv_pool])
@@ -61,7 +64,7 @@ if __name__ == "__main__":
     config = readNetworkConfiguration("networks.json")
     ifaces = config["ifaces"]
     docker_networks = config["docker_networks"]
-    
+
     for iface in ifaces:
         connect(iface, ifaces[iface]['ssid'], ifaces[iface]['password'])
     for network in docker_networks:

--- a/rtl_device/networks.json
+++ b/rtl_device/networks.json
@@ -1,0 +1,16 @@
+{
+    "ifaces" : {
+        "wlx90de80aa59de" : {
+            "ssid" : "",
+            "password" : ""
+        }
+    },
+    "docker_networks" : {
+        "dji-tello-1" : {
+            "iface" : "",
+            "gateway" : "192.168.0.1",
+            "subnet" : "192.168.0.0/24"
+        }
+    }
+
+}


### PR DESCRIPTION
[Готово](https://github.com/OSLL/tello-dev/issues/35)

Пример работы:
```
2024-03-16 07:23:44.684 | INFO     | __main__:connect:17 - Connecting device 'wlx90de80aa59de' to 'Xiaomi_4C6C_5G'
2024-03-16 07:24:18.677 | INFO     | __main__:connect:29 - {17: [{'addr': '90:de:80:aa:59:de', 'broadcast': 'ff:ff:ff:ff:ff:ff'}], 2: [{'addr': '192.168.31.145', 'netmask': '255.255.255.0', 'broadcast': '192.168.31.255'}], 10: [{'addr': 'fe80::b174:6fe2:1da7:4d9e%wlx90de80aa59de', 'netmask': 'ffff:ffff:ffff:ffff::/64'}]}
2024-03-16 07:24:18.677 | SUCCESS  | __main__:connect:30 - Device 'wlx90de80aa59de' successfully connected to 'Xiaomi_4C6C_5G'
2024-03-16 07:24:18.727 | WARNING  | __main__:createDockerNetwork:52 - Network with name dji-tello-1 already exists, removing it...
2024-03-16 07:24:18.757 | INFO     | __main__:createDockerNetwork:56 - Removed network with id c0e436eb3b959589e641e515dc255296215a42c92968b6eda04d0a367a5fb50e
2024-03-16 07:24:18.758 | INFO     | __main__:createDockerNetwork:57 - Creating network with name dji-tello-1
```

Как результат устройства подключаются к заданным wifi сетям и создают docker сети, которые необходимо использовать при старте контейнера. Тип сети докер-сети macvlan, которые напрямую используют wifi-адаптеры.

